### PR TITLE
Enable send only

### DIFF
--- a/src/LoadTests.Sender.Router/Program.cs
+++ b/src/LoadTests.Sender.Router/Program.cs
@@ -35,6 +35,7 @@ namespace LoadTests.Sender.Router
 
             var sqlInterface = routerConfig.AddInterface<SqlServerTransport>("SQL", t =>
             {
+                t.ConnectionString(sqlConnectionString);
                 t.Transactions(TransportTransactionMode.SendsAtomicWithReceive);
             });
 

--- a/src/NServiceBus.Router.Connector/NServiceBus.Router.Connector.csproj
+++ b/src/NServiceBus.Router.Connector/NServiceBus.Router.Connector.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <OutputPath>..\..\binaries</OutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
HI, 

I created an issue a couple of days ago. In the meanwhile I tried something and I decided to do a pull request. Maybe it is of use to you. 

I have changed the RouterConnectorFeature to skip the Subscribe and UnsubcribeBehavior in case of a SendOnly endpoint as they are only necessary for Events.

I have also added a new target to the Router.Connector project, because my Service Fabric server do not have the right framework installed. 

I also had to add the connectionstring to the LoadTest.Sender.Router for the SqlServerTransport configuration, because I got the message that it is required. 

I hope it is of some use.

Regards, 
Dries
